### PR TITLE
Feature/fix store info update on admob side

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Appodeal",
   "short_name": "Appodeal Admob Sync",
   "description": "This extension will create and sync Appodeal adunits in your Admob account.",
-  "version": "16.13.23",
+  "version": "16.13.24",
   "browser_action": {
     "default_icon": {
       "16": "img/icon/icon-16.png"


### PR DESCRIPTION
Исправление механизма выбора апп для обновления информации из стора, если по бандлу нашло аппу в нескольких сторах, добавлена проверка на ос, если платформа поменялась на стороне сервера - спрятать старую аппу в адмобе и создать новую с нужной платформой.